### PR TITLE
Bhcs/fix 3d towers enemies

### DIFF
--- a/game/src/enemy/core/Enemy.gd
+++ b/game/src/enemy/core/Enemy.gd
@@ -39,6 +39,7 @@ func _ready() -> void:
 	collision_timer.set_paused(true)
 
 func _physics_process(delta: float) -> void:
+	self.z_index = self.global_position.y / 10.0
 	if action == ACTION.DIE:
 		return
 	elif !damage_taken_timer.is_stopped():

--- a/game/src/environment/map/Map.gd
+++ b/game/src/environment/map/Map.gd
@@ -72,6 +72,7 @@ func build_tower(x: int, y: int, tower_type: String) -> bool:
 	var tower : Tower = load(tower_type).instance()
 	add_child(tower)
 	tower.build_at(Vector2(x + 0.5, y + 0.5) * TILE_SIZE)
+	tower.z_index = tower.global_position.y / 10.0
 	tower_at[x][y] = weakref(tower)
 	tile_at[x][y] = TILE_CONTENTS.TOWER
 	return true
@@ -91,10 +92,3 @@ func dismantle_tower(x: int, y: int) -> bool:
 	tower_at[x][y] = null
 	tile_at[x][y] = TILE_CONTENTS.EMPTY
 	return true
-
-func build_turret_at(x: int, y: int) -> void:
-#	var turret = load($BuildUI.tower_to_be_built)
-#	add_child(turret)
-#	turret.position(Vector2(x,y) * TILE_SIZE)
-	pass 
-	

--- a/game/src/environment/towers/core/Tower.tscn
+++ b/game/src/environment/towers/core/Tower.tscn
@@ -111,7 +111,6 @@ scale = Vector2( 0.5, 0.5 )
 script = ExtResource( 2 )
 
 [node name="mainlevbuild" type="Sprite" parent="."]
-position = Vector2( 0, 48 )
 scale = Vector2( 0.50498, 0.40625 )
 texture = ExtResource( 1 )
 hframes = 7

--- a/game/src/environment/towers/pixelTowers/demonStatue/DemonStatue.tscn
+++ b/game/src/environment/towers/pixelTowers/demonStatue/DemonStatue.tscn
@@ -169,10 +169,10 @@ animations = [ {
 [node name="Tower" instance=ExtResource( 1 )]
 
 [node name="AnimatedSprite" parent="." index="4"]
-position = Vector2( 9.53674e-07, -22.4062 )
-scale = Vector2( 0.999167, 0.853274 )
+position = Vector2( 0, -112 )
+scale = Vector2( 1.7249, 1.47304 )
 frames = SubResource( 32 )
 animation = "Idle"
-frame = 16
+frame = 4
 speed_scale = 0.5
 playing = true

--- a/game/src/environment/towers/pixelTowers/eyeTower/EyeTower.tscn
+++ b/game/src/environment/towers/pixelTowers/eyeTower/EyeTower.tscn
@@ -162,15 +162,10 @@ animations = [ {
 
 [node name="Tower" instance=ExtResource( 1 )]
 
-[node name="AnimatedSprite" parent="TowerInventory" index="1"]
-position = Vector2( 832, 384 )
-scale = Vector2( 2.765, 2.625 )
-frames = SubResource( 15 )
-animation = "Idle"
-
 [node name="AnimatedSprite" parent="." index="4"]
-scale = Vector2( 1.25, 1.25 )
-frames = SubResource( 30 )
+position = Vector2( 0, -64 )
+scale = Vector2( 1.905, 1.905 )
+frames = SubResource( 15 )
 animation = "Idle"
 frame = 2
 playing = true

--- a/game/src/environment/towers/pixelTowers/flyingObelisk/flyingObelisk.tscn
+++ b/game/src/environment/towers/pixelTowers/flyingObelisk/flyingObelisk.tscn
@@ -79,8 +79,8 @@ animations = [ {
 [node name="FlyingObelisk" instance=ExtResource( 1 )]
 
 [node name="AnimatedSprite" parent="." index="4"]
-position = Vector2( -1.13687e-13, -8 )
-scale = Vector2( 0.47, 0.365 )
+position = Vector2( 0, -128 )
+scale = Vector2( 0.979375, 0.760578 )
 frames = SubResource( 14 )
 animation = "Idle"
 frame = 7

--- a/game/src/environment/towers/pixelTowers/lightningTotem/LightningTotem.tscn
+++ b/game/src/environment/towers/pixelTowers/lightningTotem/LightningTotem.tscn
@@ -77,8 +77,8 @@ animations = [ {
 wait_time = 0.7
 
 [node name="AnimatedSprite" parent="." index="4"]
-position = Vector2( 0, -40 )
-scale = Vector2( 1.4, 1.4 )
+position = Vector2( 0, -144 )
+scale = Vector2( 2.495, 2.495 )
 frames = SubResource( 13 )
 animation = "Idle"
 frame = 7

--- a/game/src/environment/towers/pixelTowers/moonTower/MoonTower.tscn
+++ b/game/src/environment/towers/pixelTowers/moonTower/MoonTower.tscn
@@ -72,6 +72,8 @@ animations = [ {
 wait_time = 0.5
 
 [node name="AnimatedSprite" parent="." index="4"]
+position = Vector2( 0, -80 )
+scale = Vector2( 1.37, 1.485 )
 frames = SubResource( 12 )
 animation = "Idle"
 frame = 10

--- a/game/src/environment/towers/pixelTowers/obelisk/Obelisk.tscn
+++ b/game/src/environment/towers/pixelTowers/obelisk/Obelisk.tscn
@@ -83,9 +83,9 @@ animations = [ {
 
 [node name="Tower" instance=ExtResource( 2 )]
 
-[node name="AnimatedSprite" parent="." index="3"]
-position = Vector2( 0, -32 )
-scale = Vector2( 0.6, 0.513 )
+[node name="AnimatedSprite" parent="." index="4"]
+position = Vector2( 6, -134 )
+scale = Vector2( 1.05789, 0.9045 )
 frames = SubResource( 15 )
 animation = "Idle"
 frame = 1


### PR DESCRIPTION
Previously, enemies and towers used to overlap purely based on age (time since added to scene tree). This meant a later tower will always overlap a previously built tower, even when it is positioned behind and expected to be partially obscured. Likewise, enemies would overlap in a similar fashion, breaking the illusion of a 3 dimension, oblique point of view.

commit 6d9f1d60a8d23e2a1c6864a284d1b2ac4bcee2b1    Resize towers now that z axis is defined.
* Reposition the base so that the base sprite fills 64 x 64
* Resize towers so that their base fills the 'ground' part of the base sprite.

commit 7c2293f29ce68df301fa31ae88c2b1eb07187374    Have enemy and towers update their z-axis.
From now on this is the new standard: z index is always the y of the global position / 10.0
* When map does the `build_tower_at(..)` function, remember to update the z index as per current y global position
* When each enemy instance runs `physics_process(..)` function, update its z index as per current y global position

How it looks now:
<img width="430" alt="image" src="https://user-images.githubusercontent.com/7360964/120887630-9a9d7780-c626-11eb-9d6c-38baa09c8082.png">
