### PR TITLE
Patch bug (not updating items)

### DIFF
--- a/game/GetChest.gd
+++ b/game/GetChest.gd
@@ -1,0 +1,10 @@
+extends Control
+
+
+
+
+func _on_GoldChest_pressed():
+	print("Get gold")
+
+func _on_ItemChest_pressed():
+	print("Get item")

--- a/game/src/environment/towers/core/Tower.gd
+++ b/game/src/environment/towers/core/Tower.gd
@@ -122,8 +122,11 @@ func _on_Range_body_exited(body: Node) -> void:
 	if body is Enemy:
 		_forget_enemy(body)
 
-func update_items():
+func update_items(item_slot : String = "", item = null):
 	_reset()
+
+	if (item_slot != ""):
+		tower_items_held[item_slot] = item
 
 	itemsHeld[0] = tower_items_held["Slot1"]
 	itemsHeld[1] = tower_items_held["Slot2"]

--- a/game/src/ui/gameplay/BuildTool/BuildUI.gd
+++ b/game/src/ui/gameplay/BuildTool/BuildUI.gd
@@ -222,3 +222,12 @@ func make_buildUI_visible():
 func make_buildUI_invisible():
 	self.scale = Vector2.ZERO
 	is_visible = false
+
+func can_drop_data(position, data):
+	return true
+
+func drop_data(position, data):
+	print("Dropped here")
+	data["target_slot"] = data["origin_slot"]
+	data["target_item"] = data["origin_item"]
+	data["origin_slot"].texture = data["origin_texture"]

--- a/game/src/ui/gameplay/BuildTool/BuildUI.gd
+++ b/game/src/ui/gameplay/BuildTool/BuildUI.gd
@@ -71,7 +71,9 @@ var build_UI_items_held : Dictionary = {
 	"Slot10" : null
 }
 
-
+func update_slot(slot_name : String, item = null):
+	if slot_name != "":
+		build_UI_items_held[slot_name] = item;
 
 onready var tileSelector: TileSelector = find_parent("Arena").get_node("Selector")
 # TODO: change below to Arena, or delete if not necessary (best practice: minimise calls to parent)

--- a/game/src/ui/gameplay/BuildTool/buildUISlot.gd
+++ b/game/src/ui/gameplay/BuildTool/buildUISlot.gd
@@ -52,8 +52,8 @@ func drop_data(position, data):
 		if (origin_slot.is_in_group("TowerInventorySlots")):
 			data["target_item"] = null
 			data["target_texture"] = null
-			build_UI.build_UI_items_held[target_slot_name] = data["origin_item"]
-			tower_inventory.tower_inventory_items_held[origin_slot_name] = null
+			build_UI.update_slot(target_slot_name, data["origin_item"])
+			tower_inventory.update_tower(origin_slot_name, null)
 			texture = data["origin_texture"]
 	
 	#Swapping between items 
@@ -68,8 +68,8 @@ func drop_data(position, data):
 
 			#for actual info swap
 			var temp_item_for_swap = target_slot_item
-			build_UI.build_UI_items_held[target_slot_name] = origin_slot_item
-			build_UI.build_UI_items_held[origin_slot_name] = temp_item_for_swap
+			build_UI.update_slot(target_slot_name, origin_slot_item)
+			build_UI.update_slot(origin_slot_name, temp_item_for_swap)
 		
 		elif (origin_slot.is_in_group("TowerInventorySlots")):
 			data["target_item"] = target_slot_item
@@ -80,8 +80,8 @@ func drop_data(position, data):
 
 			#For actual Info Swap
 			var temp_item_for_swap = target_slot_item
-			build_UI.build_UI_items_held[target_slot_name] = origin_slot_item
-			tower_inventory.tower_inventory_items_held[origin_slot_name] = temp_item_for_swap			
+			build_UI.update_slot(target_slot_name, origin_slot_item)
+			tower_inventory.update_tower(origin_slot_name, temp_item_for_swap)
 	tower_inventory.update_tower()
 
 

--- a/game/src/ui/gameplay/UI/UI.gd
+++ b/game/src/ui/gameplay/UI/UI.gd
@@ -9,6 +9,7 @@ func can_drop_data(position, data):
 	return true
 
 func drop_data(position, data):
+	print("Dropped here")
 	data["target_slot"] = data["origin_slot"]
 	data["target_item"] = data["origin_item"]
 	data["origin_slot"].texture = data["origin_texture"]

--- a/game/src/ui/gameplay/UI/UI.tscn
+++ b/game/src/ui/gameplay/UI/UI.tscn
@@ -464,8 +464,9 @@ __meta__ = {
 }
 
 [node name="PanelContainer" type="PanelContainer" parent="Control/BuildUI/VBoxContainer"]
+margin_top = 40.0
 margin_right = 1920.0
-margin_bottom = 280.0
+margin_bottom = 320.0
 custom_styles/panel = SubResource( 5 )
 script = ExtResource( 19 )
 __meta__ = {
@@ -664,14 +665,17 @@ margin_right = 200.0
 margin_bottom = 64.0
 rect_min_size = Vector2( 64, 64 )
 custom_styles/panel = SubResource( 7 )
+script = ExtResource( 19 )
 
 [node name="TextureRect" type="TextureRect" parent="Control/BuildUI/VBoxContainer/PanelContainer/PanelContainer/MarginContainer/HBoxContainer/ItemSlots/Slot3"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 9.99994
-margin_top = 9.99997
-margin_right = -10.0001
-margin_bottom = -11.0
+anchor_left = 0.0248585
+anchor_top = -0.00426292
+anchor_right = 1.02486
+anchor_bottom = 0.995737
+margin_left = 10.409
+margin_top = 10.2728
+margin_right = -9.59103
+margin_bottom = -10.7272
 expand = true
 script = ExtResource( 7 )
 __meta__ = {

--- a/game/src/ui/gameplay/towerInventory/QuantumCircuitSlot.gd
+++ b/game/src/ui/gameplay/towerInventory/QuantumCircuitSlot.gd
@@ -3,65 +3,7 @@ extends "res://src/ui/gameplay/towerInventory/TowerInventorySlot.gd"
 #Override can drop data function
 func can_drop_data(position, data):
 	var item = data["origin_item"]
-	if (item.isTensor == true):
-		return true
-	else: 
-		return false
-
-func drop_data(position, data):
-	var target_slot_name : String = get_parent().get_name()
-	var target_slot = get_parent()
-	var target_slot_item = tower_inventory.tower_inventory_items_held[target_slot_name]
-	
-	var origin_slot_name = data["origin_slot_name"]
-	var origin_slot = data["origin_slot"].get_parent()
-	var origin_slot_item = data["origin_item"]
-
-	#Target slot is null 
-	if (target_slot_item == null):
-		#If target slot belongs to build UI. E.g just shifting within BuildUI
-		if (origin_slot.is_in_group("BuildUISlots")):
-			data["target_item"] = null
-			data["target_texture"] = null
-			tower_inventory.tower_inventory_items_held[target_slot_name] = data["origin_item"]
-			build_UI.build_UI_items_held[origin_slot_name] = null
-			texture = data["origin_texture"]
-			
-		#If target slot belongs to Tower inventory. E.g equipping item
-		elif (origin_slot.is_in_group("TowerInventorySlots")):
-			data["target_item"] = null
-			data["target_texture"] = null
-			tower_inventory.tower_inventory_items_held[target_slot_name] = data["origin_item"]
-			tower_inventory.tower_inventory_items_held[origin_slot_name] = null
-			texture = data["origin_texture"]
-		
-	#Swapping between items 
-	else: 
-		#If the item swap is within buildUI
-		if (origin_slot.is_in_group("BuildUISlots")):
-			data["target_item"] = target_slot_item
-			
-			#Swap for textures
-			data["origin_slot"].texture = target_slot.get_child(0).texture
-			texture = data["origin_texture"]
-			
-			#Swap for actual info
-			var temp_item_for_swap = target_slot_item
-			tower_inventory.tower_inventory_items_held[target_slot_name] = origin_slot_item
-			build_UI.build_UI_items_held[origin_slot_name] = temp_item_for_swap
-
-		elif (target_slot.is_in_group("TowerInventorySlots")):
-			data["target_item"] = target_slot_item
-			
-			#Swap for textures
-			data["origin_slot"].texture = target_slot.get_child(0).texture
-			texture = data["origin_texture"]
-
-			#Swap for actual info
-			var temp_item_for_swap = target_slot_item
-			tower_inventory.tower_inventory_items_held[target_slot_name] = origin_slot_item
-			tower_inventory.tower_inventory_items_held[origin_slot_name] = temp_item_for_swap
-	tower_inventory.update_tower()
+	return item != null and item.isTensor
 
 func update_tower_quantum_circuit():
 		pass

--- a/game/src/ui/gameplay/towerInventory/TowerInventory.gd
+++ b/game/src/ui/gameplay/towerInventory/TowerInventory.gd
@@ -23,9 +23,13 @@ func delete_children(node):
 			n.queue_free()
 
 
-func update_tower():
+func update_tower(slot_name : String = "", item = null):
+
+	if slot_name != "":
+		tower_inventory_items_held[slot_name] = item;
+
 	#Update all the tower items
-	tower_to_be_built.update_items()
+	tower_to_be_built.update_items(slot_name, item)
 	
 	#Update probability bar
 	var prob: Dictionary = tower_to_be_built.probs

--- a/game/src/ui/gameplay/towerInventory/TowerInventory.gd
+++ b/game/src/ui/gameplay/towerInventory/TowerInventory.gd
@@ -13,15 +13,11 @@ onready var build_ui = get_parent().get_node("BuildUI")
 var tower_display_reference = Vector2(1690,275)
 onready var prob_bar = self.get_node("TextureRect/ProbabiilityBar")
 
-
-
-
 #Remove all children nodes	
 func delete_children(node):
 	for n in node.get_children():
 			node.remove_child(n)
 			n.queue_free()
-
 
 func update_tower(slot_name : String = "", item = null):
 

--- a/game/src/ui/gameplay/towerInventory/TowerInventorySlot.gd
+++ b/game/src/ui/gameplay/towerInventory/TowerInventorySlot.gd
@@ -54,7 +54,7 @@ func drop_data(position, data):
 		if (origin_slot.is_in_group("BuildUISlots")):
 			data["target_item"] = null
 			data["target_texture"] = null
-			tower_inventory.tower_inventory_items_held[target_slot_name] = data["origin_item"]
+			tower_inventory.update_tower(target_slot_name, data["origin_item"])
 			build_UI.build_UI_items_held[origin_slot_name] = null
 			texture = data["origin_texture"]
 			

--- a/game/src/ui/gameplay/towerInventory/TowerInventorySlot.gd
+++ b/game/src/ui/gameplay/towerInventory/TowerInventorySlot.gd
@@ -55,15 +55,15 @@ func drop_data(position, data):
 			data["target_item"] = null
 			data["target_texture"] = null
 			tower_inventory.update_tower(target_slot_name, data["origin_item"])
-			build_UI.build_UI_items_held[origin_slot_name] = null
+			build_UI.update_slot(origin_slot_name, null)
 			texture = data["origin_texture"]
 			
 		#If target slot belongs to Tower inventory. E.g equipping item
 		elif (origin_slot.is_in_group("TowerInventorySlots")):
 			data["target_item"] = null
 			data["target_texture"] = null
-			tower_inventory.tower_inventory_items_held[target_slot_name] = data["origin_item"]
-			tower_inventory.tower_inventory_items_held[origin_slot_name] = null
+			tower_inventory.update_tower(target_slot_name, data["origin_item"])
+			tower_inventory.update_tower(origin_slot_name, null)
 			texture = data["origin_texture"]
 		
 	#Swapping between items 
@@ -78,8 +78,8 @@ func drop_data(position, data):
 			
 			#Swap for actual info
 			var temp_item_for_swap = target_slot_item
-			tower_inventory.tower_inventory_items_held[target_slot_name] = origin_slot_item
-			build_UI.build_UI_items_held[origin_slot_name] = temp_item_for_swap
+			tower_inventory.update_tower(target_slot_name, origin_slot_item)
+			build_UI.update_slot(origin_slot_name, temp_item_for_swap)
 
 		elif (target_slot.is_in_group("TowerInventorySlots")):
 			data["target_item"] = target_slot_item
@@ -90,8 +90,8 @@ func drop_data(position, data):
 
 			#Swap for actual info
 			var temp_item_for_swap = target_slot_item
-			tower_inventory.tower_inventory_items_held[target_slot_name] = origin_slot_item
-			tower_inventory.tower_inventory_items_held[origin_slot_name] = temp_item_for_swap
+			tower_inventory.update_tower(target_slot_name, origin_slot_item)
+			tower_inventory.update_tower(origin_slot_name, origin_slot_item)
 	tower_inventory.update_tower()
 
 	# print("________________________")


### PR DESCRIPTION
* We had previously removed the OOP way of Tower.gd (update items) and had it solely do a refresh (cuz TowerInventory was stepping in to deal with items_held directly)
* I updated Tower.gd (update items) to be able to actually update items as required not OOP still, but this works well without fear of memory leaks or anyone mishandling the Tower.gd variables or data
* Updated TowerInventory and TowerInventory slots based on the changes.

* Deleted massive chunks of code in Quantum CircuitSlot that had nothing to do with this bug, its just a script that inherited from TowerInventorySlot.gd and did not need so many lines.